### PR TITLE
Add removeBottomCRTBackendFiles.sh

### DIFF
--- a/Xporter/bottomcrt_crontab.ctab
+++ b/Xporter/bottomcrt_crontab.ctab
@@ -1,1 +1,2 @@
+MAILTO=mvicenzi@bnl.gov
 25 1 */2 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeBottomCRTBackendFiles.sh

--- a/Xporter/bottomcrt_crontab.ctab
+++ b/Xporter/bottomcrt_crontab.ctab
@@ -1,0 +1,1 @@
+25 1 */2 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeBottomCRTBackendFiles.sh

--- a/Xporter/logfile_crontab.ctab
+++ b/Xporter/logfile_crontab.ctab
@@ -1,1 +1,2 @@
+35 0 */1 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/backupTriggerLogs.sh
 5 1 */1 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeOldLogFiles.sh

--- a/Xporter/removeBottomCRTBackendFiles.sh
+++ b/Xporter/removeBottomCRTBackendFiles.sh
@@ -6,4 +6,4 @@ echo "Running removeBottomCRTBackendFiles.sh at ${timestamp}"
 # 2024-03-21 MV: commenting out the ssh command, cronjobs don't pick up kerberos tickets easily so moving to running this directly on icarus_crt11
 #ssh icarus-crt11 "find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +"
 
-find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +
+find /scratch_local/crt_tests/backend_data/ -path "/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*" -type f -mtime +7 -exec rm -f '{}' +

--- a/Xporter/removeBottomCRTBackendFiles.sh
+++ b/Xporter/removeBottomCRTBackendFiles.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-ssh icarus-crt11 "find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +"
+# 2024-03-21 MV: commenting out the ssh command, cronjobs don't pick up kerberos tickes easily so moving to running this directly on icarus_crt11
+#ssh icarus-crt11 "find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +"
+
+find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +

--- a/Xporter/removeBottomCRTBackendFiles.sh
+++ b/Xporter/removeBottomCRTBackendFiles.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# 2024-03-21 MV: commenting out the ssh command, cronjobs don't pick up kerberos tickes easily so moving to running this directly on icarus_crt11
+timestamp=`date +%Y_%m_%d_%H_%M`
+echo "Running removeBottomCRTBackendFiles.sh at ${timestamp}"
+
+# 2024-03-21 MV: commenting out the ssh command, cronjobs don't pick up kerberos tickets easily so moving to running this directly on icarus_crt11
 #ssh icarus-crt11 "find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +"
 
 find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +

--- a/Xporter/removeBottomCRTBackendFiles.sh
+++ b/Xporter/removeBottomCRTBackendFiles.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ssh icarus-crt11 "find /scratch_local/crt_tests/backend_data/ -path \"/scratch_local/crt_tests/backend_data/runs1/DATA/Run_*/binary/*\" -type f -mtime +7 -exec rm -f '{}' +"

--- a/Xporter/update_crontabs.sh
+++ b/Xporter/update_crontabs.sh
@@ -14,7 +14,7 @@ done
 
 for server in icarus-evb06
 do
-    cat $1 logfile_crontab.ctab icarus_evb06_db.ctab > tmp.ctab
+    cat $1 logfile_crontab.ctab bottomcrt_crontab.ctab icarus_evb06_db.ctab > tmp.ctab
     echo "crontab to add:"
     cat tmp.ctab
     echo "Executing: ssh ${server} crontab ~icarus/FileTransfer/sbndaq-xporter/Xporter/tmp.ctab"

--- a/Xporter/update_crontabs.sh
+++ b/Xporter/update_crontabs.sh
@@ -14,10 +14,21 @@ done
 
 for server in icarus-evb06
 do
-    cat $1 logfile_crontab.ctab bottomcrt_crontab.ctab icarus_evb06_db.ctab > tmp.ctab
+    cat $1 logfile_crontab.ctab icarus_evb06_db.ctab > tmp.ctab
     echo "crontab to add:"
     cat tmp.ctab
     echo "Executing: ssh ${server} crontab ~icarus/FileTransfer/sbndaq-xporter/Xporter/tmp.ctab"
     ssh $server "crontab ~icarus/FileTransfer/sbndaq-xporter/Xporter/tmp.ctab"
     rm tmp.ctab
 done
+
+for server in icarus-crt11
+do
+    cat $1 bottomcrt_crontab.ctab > tmp.ctab
+    echo "crontab to add:"
+    cat tmp.ctab
+    echo "Executing: ssh ${server} crontab ~icarus/FileTransfer/sbndaq-xporter/Xporter/tmp.ctab"
+    ssh $server "crontab ~icarus/FileTransfer/sbndaq-xporter/Xporter/tmp.ctab"
+    rm tmp.ctab
+done
+

--- a/Xporter/xporter_crontab.ctab
+++ b/Xporter/xporter_crontab.ctab
@@ -1,4 +1,4 @@
-MAILTO=wketchum@fnal.gov
+MAILTO=wketchum@fnal.gov,mvicenzi@bnl.gov
 */1 * * * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/runXporter.sh
 1 */1 * * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeOnMonFiles.sh
 2 */1 * * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeTestDirFiles.sh

--- a/Xporter/xporter_crontab_noxporter.ctab
+++ b/Xporter/xporter_crontab_noxporter.ctab
@@ -1,4 +1,4 @@
-MAILTO=wketchum@fnal.gov
+MAILTO=wketchum@fnal.gov,mvicenzi@bnl.gov
 #*/1 * * * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/runXporter.sh
 1 */1 * * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeOnMonFiles.sh
 2 */1 * * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeTestDirFiles.sh


### PR DESCRIPTION
This PR adds `removeBottomCRTBackendFiles.sh` which is meant to remove the backend binary files produced by the bottom CRTs on `icarus-crt11` if they are older than one week. This scripts runs in a cronjob from user `icarus` on `icarus-crt11`. 

The crontab command is saved in `bottomcrt_crontab.ctab` for posterity. I'm also updating the other `*.ctab` files with most up-to-date info.

Waiting until we confim the cronjob is running correctly before merging.