### PR TITLE
Updates to the offbeam minbias streams

### DIFF
--- a/Xporter/X_SAM_metadata.py
+++ b/Xporter/X_SAM_metadata.py
@@ -99,8 +99,11 @@ def SAM_metadata(filename, projectvers, projectname):
 
         metadata["configuration.name"] = dictionary.get('configuration')
 
-        if "Calibration" in metadata["configuration.name"] and metadata["data_stream"]=="offbeamminbias":
+        if "Physics"!=metadata["configuration.name"][0:7] and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
             metadata["data_stream"]="offbeamminbiascalib"
+	#we should be able to do the latter, but we (Ivan, Donatella, Matteo, and Wes) decided 7 Mar 2024 to not distinguish here, since there _could_ __potentially__ be something different
+        #elif metadata["configuration.name"][0:7]=="Physics" and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
+	#    metadata["data_stream"]="offbeamminbias"
         
         s = dictionary.get('configuration').lower()
     except Exception as e:

--- a/Xporter/X_SAM_metadata.py
+++ b/Xporter/X_SAM_metadata.py
@@ -99,7 +99,7 @@ def SAM_metadata(filename, projectvers, projectname):
 
         metadata["configuration.name"] = dictionary.get('configuration')
 
-        if "Physics"!=metadata["configuration.name"][0:7] and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
+        if "Physics"!=metadata["configuration.name"][0:7] and "Overlays"!=metadata["configuration.name"][0:8] and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
             metadata["data_stream"]="offbeamminbiascalib"
 	#we should be able to do the latter, but we (Ivan, Donatella, Matteo, and Wes) decided 7 Mar 2024 to not distinguish here, since there _could_ __potentially__ be something different
         #elif metadata["configuration.name"][0:7]=="Physics" and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
@@ -121,9 +121,13 @@ def SAM_metadata(filename, projectvers, projectname):
     zerobias = "zerobias"
     bnbnumi = "common"
 
-    if ((beambnb in s and s.find(beamnumi) == -1) or stream=='bnb' or stream=='bnbmajority' or stream=='bnbminbias'):
+    #if ((beambnb in s and s.find(beamnumi) == -1) or stream=='bnb' or stream=='bnbmajority' or stream=='bnbminbias'):
+    ## MV: we no longer use beam-specific configuration names, stop using it to set the beam type
+    if (stream=='bnb' or stream=='bnbmajority' or stream=='bnbminbias'):
        beam = "BNB"
-    elif ((beamnumi in s and s.find(beambnb) == -1) or stream=='numi' or stream=='numimajority' or stream=='numiminbias'):
+    #elif ((beamnumi in s and s.find(beambnb) == -1) or stream=='numi' or stream=='numimajority' or stream=='numiminbias'):
+    ## MV: we no longer use beam-specific configuration names, stop using it to set the beam type
+    elif (stream=='numi' or stream=='numimajority' or stream=='numiminbias'):
        beam = "NUMI"
     elif ( zerobias or laser) in s:
        beam = "none"

--- a/Xporter/X_SAM_metadata.py
+++ b/Xporter/X_SAM_metadata.py
@@ -99,12 +99,15 @@ def SAM_metadata(filename, projectvers, projectname):
 
         metadata["configuration.name"] = dictionary.get('configuration')
 
+        if "Calibration" in metadata["configuration.name"] and metadata["data_stream"]=="offbeamminbias":
+            metadata["data_stream"]="offbeamminbiascalib"
+        
         s = dictionary.get('configuration').lower()
     except Exception as e:
         print('X_SAM_Metadata.py exception: '+ str(e))
         print(datetime.now().strftime("%T"), "Failed to connect to RunHistoryReader")
 
-
+        
     metadata["icarus_project.stage"] = "daq" #runperiod(int(run_num)) 
 
        


### PR DESCRIPTION
This PR updates the data stream definitions by adding the _offbeamminbiascalib_ data stream.
This change has been effective since run 11977.

Any configuration whose name doesn't start with `Physics` now puts offbeam minbias files in a single data stream (_offbeamminbiascalib_) instead of _offbeambnbminbias_ or _offbeamnumiminbias_ .
In the absence of beam gates, this distinction is in fact meaningless. 
Note that the file names themselves have not been changed.

For now, we decided not to merge _offbeambnbminbias_ and _offbeamnumiminbias_ from `Physics` configurations into a single data stream. 

**EDIT: new changes on 04/11/2024**:

Since run 11977, all configuration names that did NOT start with `Physics` have been sending their offbeam files to the new _offbeamminbiascalib_ stream. As of run 11860, the logic has been changed to also exclude configurations that start with `Overlays`.

As a result, the offbeamminbias files created in configurations like `Physics_%` and `Overlays_%` are now both ending-up in the _offbeam(bnb/numi)minbias_ streams.

In addition, the logic that sets the `sbn_dm.beam_type` in the metadata has also been updated. Previously, if the configuration name contained either "NuMI" or "BNB", the beam type was classified in that way regardless of the data stream. The beam type definition  now follows the data stream and it defaults to "none" in case of offbeam streams. 