### PR TITLE
Raise exceptions for empty metadata entries

### DIFF
--- a/Xporter/X_SAM_metadata.py
+++ b/Xporter/X_SAM_metadata.py
@@ -65,7 +65,6 @@ def SAM_metadata(filename, projectvers, projectname):
 
     print("Checksum = %s" % checksumstr)
 
-
     #time
     gmt = time.gmtime(os.stat(filename).st_mtime)
     time_tuple =time.struct_time(gmt) #strftime("%d-%b-%Y %H:%M:%S",gmt)
@@ -76,11 +75,9 @@ def SAM_metadata(filename, projectvers, projectname):
 
     #print "Creation time:", timestr
 
-    
     metadata["checksum"] = [ checksumstr ]  
     
     #ICARUS specific fields for bookkeping 
-
 
     try:
         result=offline_run_history.RunHistoryiReader().read(run_num)
@@ -91,25 +88,31 @@ def SAM_metadata(filename, projectvers, projectname):
             result = offline_run_history.RunHistoryiReader(ucondb_uri='https://dbdata0vm.fnal.gov:9443/icarus_on_ucon_prod/app/data/run_records/configuration/key=%d').read(run_num)
             dictionary={**result[1]}
 
-        version = dictionary.get('projectversion')
+        version = dictionary['projectversion']
 
         metadata["icarus_project.version"] = version.rsplit()[0] #"raw_%s" % projectvers  
 
         metadata["icarus_project.name"] = "icarus_daq_%s" % version.rsplit()[0] #projectname
 
-        metadata["configuration.name"] = dictionary.get('configuration')
+        metadata["configuration.name"] = dictionary['configuration']
 
         if "Physics"!=metadata["configuration.name"][0:7] and "Overlays"!=metadata["configuration.name"][0:8] and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
             metadata["data_stream"]="offbeamminbiascalib"
-	#we should be able to do the latter, but we (Ivan, Donatella, Matteo, and Wes) decided 7 Mar 2024 to not distinguish here, since there _could_ __potentially__ be something different
+	#we should be able to do the latter, but we (Ivan, Donatella, Matteo, and Wes) decided 7 Mar 2024 to not distinguish here
+        #since there _could_ __potentially__ be something different
         #elif metadata["configuration.name"][0:7]=="Physics" and (metadata["data_stream"]=="offbeamnumiminbias" or metadata["data_stream"]=="offbeambnbminbias"):
 	#    metadata["data_stream"]="offbeamminbias"
         
-        s = dictionary.get('configuration').lower()
+        s = dictionary['configuration'].lower()
+
+    except KeyError as e:
+        print("X_SAM_Metadata.py exception: "+str(e))
+        print(datetime.now().strftime("%T"), "Missing metadata value in database")
+
     except Exception as e:
         print('X_SAM_Metadata.py exception: '+ str(e))
         print(datetime.now().strftime("%T"), "Failed to connect to RunHistoryReader")
-
+    
         
     metadata["icarus_project.stage"] = "daq" #runperiod(int(run_num)) 
 

--- a/Xporter/Xporter.py
+++ b/Xporter/Xporter.py
@@ -1,7 +1,7 @@
  #  Usage: python Xporter.py <data directory> <dropbox directory>
 #
 # program to:
-#       1)  Check to see if there are new files and if there are:
+#       1) Check to see if there are new files and if there are:
 #       2) update run configuration database
 #       3) create the SAM metadata file
 #       4) move the data file to the dropbox


### PR DESCRIPTION
This PR addresses the issue seen in ELOG entries [208493](https://dbweb8.fnal.gov:8443/ECL/sbnfd/E/show?e=208493), [212677](https://dbweb8.fnal.gov:8443/ECL/sbnfd/E/show?e=212677) and [214955](https://dbweb8.fnal.gov:8443/ECL/sbnfd/E/show?e=214955).

In those instances, the metadata entries that are read from the run history database (`icarus_project.version`, `configuration.name`, and `icarus_project.name`) were missing in the final `json` file. This prevented the files from being deleted by the cleanup script, but it didn't stop FTS from transferring them to the offline. 

The proposed changes allow to raise an exception in case those entries are missing, thus avoiding the creation of the `json` file altogether and preventing any transfer. In particular:

1. `dictionary.get('projectversion')` calls are changed to `dictionary['projectversion']`. The functionality is similar, but the latter actually raises a `KeyError` exception when the key is not found.
2. The `KeyError` exception is caught and used to print the reason of the error. Since `KeyError` is a subclass of `Exception`, its `except` statement needs to be placed before the one for `Exception`. In this way, database connections issues and missing entries produce different warning messages in the logfile.

These issues are usually temporary: avoiding to create the `json` file forces the `Xporter` to try again next time until it eventually succeeds. As a result, I believe these issues will fix themselves moving forward (with no manual action needed).

Reviewers: @dtorretta56 (as DAQ convener), @acampani (as she helped unclogging one of these instances).