### PR TITLE
Update FTS configuration to skip SAM proxy frontend

### DIFF
--- a/FTS_config/icarus-evb_fts_config.ini
+++ b/FTS_config/icarus-evb_fts_config.ini
@@ -3,7 +3,7 @@
 experiment=icarus
 log-file = /daq/log/fts_logs/${hostname}/fts_${hostname}
 filetypes = data_tape
-samweb-url = https://samweb.fnal.gov:8483/sam/icarus/api
+samweb-url = https://samicarus.fnal.gov:8483/sam/icarus/api
 x509-client-certificate = /opt/icarusraw/icarusraw.Raw.proxy
 x509-client-key = /opt/icarusraw/icarusraw.Raw.proxy
 


### PR DESCRIPTION
SAM proxy front-end was changed to an AL9 node. SAM projects and stuff worked fine, but FTS seemed to not play nice. Metadata declaration was failing with the following errors: 
```
2024-09-04 10:42:37-0500 [HTTP11ClientProtocol (TLSMemoryBIOProtocol),client] Work failed with: [<twisted.python.failure.Failure twisted.web.error.PageRedirect: 307 Temporary Redirect to https://samweb.fnal.gov:8483/sam/icarus/api/files?return_metadata=1&continue_on_error=1>] (declaring metadata for 25 file(s)); retrying in 180 s; retry no: 10
```
The solution was provided in INC000001180240, and required skipping the SAM proxy frontend (`samweb.fnal.gov`) for admin-only service, instead pointing directly to `samicarus.fnal.gov`. Pointing directly to samicarus is also faster as you bypass the proxy and go straight to the OKD cluster where SAM stuff lives.