### PR TITLE
Update to log removal scripts

### DIFF
--- a/Xporter/logfile_crontab.ctab
+++ b/Xporter/logfile_crontab.ctab
@@ -1,2 +1,3 @@
 35 0 */1 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/backupTriggerLogs.sh
 5 1 */1 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeOldLogFiles.sh
+5 1 */1 * * ~icarus/FileTransfer/sbndaq-xporter/Xporter/removeFTSLogFiles.sh

--- a/Xporter/removeFTSLogFiles.sh
+++ b/Xporter/removeFTSLogFiles.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# needs to run as root because fts logs 
+# are owned by both icarus and icarusraw
+find /daq/log/fts_logs/* -type f -mtime +14 -exec rm -f {} \;

--- a/Xporter/removeOldLogFiles.sh
+++ b/Xporter/removeOldLogFiles.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 find /daq/log/* -type f -mtime +90 -exec rm -f {} \;
+find /daq/log/* -type l ! -exec test -e {} \; -exec rm {} \;
+find /daq/log -type d -empty -exec rmdir {} \;
 find /daq/log/metrics/* -type f -mtime +14 -exec rm -f {} \;
-find /daq/log/fts_logs/* -type f -mtime +14 -exec rm -f {} \;
 rm /daq/log/grafana/graphite/exception.log
 rm /daq/log/grafana/carbon/listener.log
-#find /data/onmon_files -name '*.root' -type f -mtime 0.25 -delete

--- a/Xporter/removeOnMonFiles.sh
+++ b/Xporter/removeOnMonFiles.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# this needs to run on each evb machine as /data is on local disk
+# (technically only the one that runs the OM)
 find /data/onmon_files -name '*.root' -type f -mtime 0.25 -delete


### PR DESCRIPTION
- Add removal of broken soft links (run-numbered log files) in `/daq/log/*`
- Add removal of empty subdirectories of `/daq/log` (resulting from the removal of standard log files)
- Move FTS log removal to separate script to be run as `root` as it needs to remove stuff from multiple user. This allows to run the full `removeOldLogFiles.sh` script as `icarus`.
