### PR TITLE
Automatic Spack hash selection

### DIFF
--- a/Xporter/runXporter.sh
+++ b/Xporter/runXporter.sh
@@ -21,34 +21,43 @@ touch $file_lock
 # build hash depends on the current architecture
 SPACK_ENV="/daq/software/spack_packages/spack/current/NULL/share/spack/setup-env.sh"
 source ${SPACK_ENV} >> ${logfile_attempt} 2>&1  
-SPACK_ARCH="linux-$(spack arch --operating-system 2>/dev/null)-x86_64_v2"
 
-# hardcoded hash map for available ROOT builds 
-declare -A build_hash_map=(
-    [scientific7]="/zvbmgig"
-    [almalinux9]="/se7z5bo"
-)
-ROOT_BUILD_HASH="${build_hash_map[$(spack arch --operating-system 2>/dev/null)]:-}"
+SPACK_ARCH="linux-$(spack arch --operating-system 2>/dev/null)-x86_64_v2"
+ROOT_BUILD_HASH=$(spack find --format '{architecture} /{hash:7}' root 2>/dev/null | grep ${SPACK_ARCH} | head -n 1 | awk '{print $2}')
+
+echo "$now : Found ROOT build hash '$ROOT_BUILD_HASH' for ${SPACK_ARCH}" >> ${logfile_attempt} 2>&1
 
 # very often Spack doesn't load the package correctly
 # try up until then times before giving up...
 # report in logfile each attempt
 for i in {1..10}; do
-  echo "$now : Sourcing Spack ROOT build $ROOT_BUILD_HASH for ${SPACK_ARCH} (try $i)" >> ${logfile_attempt} 2>&1
-  if spack load ${ROOT_BUILD_HASH} >> ${logfile_attempt} 2>&1;
+  echo "$now : Sourcing Spack ROOT build '$ROOT_BUILD_HASH' for ${SPACK_ARCH} (try $i)" >> ${logfile_attempt} 2>&1
+  if [ -n "$ROOT_BUILD_HASH" ] || spack load ${ROOT_BUILD_HASH} >> ${logfile_attempt} 2>&1;
   then
-    echo "$now : Loaded ROOT build $ROOT_BUILD_HASH for ${SPACK_ARCH}" >> ${logfile_attempt} 2>&1;
+    echo "$now : Loaded ROOT build '$ROOT_BUILD_HASH' for ${SPACK_ARCH}" >> ${logfile_attempt} 2>&1;
     break
   else
     echo "$now : [Error] \"spack load ${ROOT_BUILD_HASH}\" failed. Retrying..." >> ${logfile_attempt} 2>&1;
     sleep $((4 + RANDOM % 3))
+    ROOT_BUILD_HASH=$(spack find --format '{architecture} /{hash:7}' root 2>/dev/null | grep ${SPACK_ARCH} | head -n 1 | awk '{print $2}')
+    sleep $((4 + RANDOM % 3))
   fi
 done
 
-# install mising python packaged (if needed)
-(( $(pip3 freeze |grep requests |wc -l) )) ||  { echo "requests is missing; installing requests..."; pip3 install --user requests; }
+PYTHON_ENV="/home/nfs/icarus/FileTransfer/venv"
+if [[ ! -d $PYTHON_ENV ]]; then
+    echo "$now : Creating python environment with $(python3 --version)" >> ${logfile_attempt}
+    python3 -m venv $PYTHON_ENV 
+    source $PYTHON_ENV/bin/activate
+    python3 -m pip install --upgrade pip -q 2>&1
+    python3 -m pip install requests -q 2>&1
+else
+    echo "$now : Activating python environment" >> ${logfile_attempt}
+    source $PYTHON_ENV/bin/activate
+fi
 
 # Run Xporter.py
+echo "$now : Running Xporter..." >> ${logfile_attempt}
 python3 -u /home/nfs/icarus/FileTransfer/sbndaq-xporter/Xporter/Xporter.py /data/daq /data/fts_dropbox none sbndaq_v1_10_02 DataXport_2024-10-18 >> ${logfile} 2>&1
 
 echo "$now : Xport Finished! Releasing lock file $file_lock now!" >> ${logfile_attempt} 2>&1

--- a/Xporter/runXporter.sh
+++ b/Xporter/runXporter.sh
@@ -23,7 +23,7 @@ SPACK_ENV="/daq/software/spack_packages/spack/current/NULL/share/spack/setup-env
 source ${SPACK_ENV} >> ${logfile_attempt} 2>&1  
 
 SPACK_ARCH="linux-$(spack arch --operating-system 2>/dev/null)-x86_64_v2"
-ROOT_BUILD_HASH=$(spack find --format '{architecture} /{hash:7}' root 2>/dev/null | grep ${SPACK_ARCH} | head -n 1 | awk '{print $2}')
+ROOT_BUILD_HASH=$(spack find --format '{architecture} /{hash:7}' root 2>/dev/null | grep -m 1 ${SPACK_ARCH} | awk '{print $2}')
 
 echo "$now : Found ROOT build hash '$ROOT_BUILD_HASH' for ${SPACK_ARCH}" >> ${logfile_attempt} 2>&1
 
@@ -32,14 +32,14 @@ echo "$now : Found ROOT build hash '$ROOT_BUILD_HASH' for ${SPACK_ARCH}" >> ${lo
 # report in logfile each attempt
 for i in {1..10}; do
   echo "$now : Sourcing Spack ROOT build '$ROOT_BUILD_HASH' for ${SPACK_ARCH} (try $i)" >> ${logfile_attempt} 2>&1
-  if [ -n "$ROOT_BUILD_HASH" ] || spack load ${ROOT_BUILD_HASH} >> ${logfile_attempt} 2>&1;
+  if [ -n "$ROOT_BUILD_HASH" ] && spack load ${ROOT_BUILD_HASH} >> ${logfile_attempt} 2>&1;
   then
     echo "$now : Loaded ROOT build '$ROOT_BUILD_HASH' for ${SPACK_ARCH}" >> ${logfile_attempt} 2>&1;
     break
   else
     echo "$now : [Error] \"spack load ${ROOT_BUILD_HASH}\" failed. Retrying..." >> ${logfile_attempt} 2>&1;
     sleep $((4 + RANDOM % 3))
-    ROOT_BUILD_HASH=$(spack find --format '{architecture} /{hash:7}' root 2>/dev/null | grep ${SPACK_ARCH} | head -n 1 | awk '{print $2}')
+    ROOT_BUILD_HASH=$(spack find --format '{architecture} /{hash:7}' root 2>/dev/null | grep -m 1 ${SPACK_ARCH} | awk '{print $2}')
     sleep $((4 + RANDOM % 3))
   fi
 done


### PR DESCRIPTION
`X_SAM_metadata.py` requires setting up `pyROOT` by loading the relevant Spack ROOT package. Previously, this was done using a hardcoded map which required updates at any new spack-sbndaq release. This PR introduces: 

1.  an automatic way of selecting the appropriate Spack hash for the ROOT package according to the host architectures. Since there are only loose requirements on the ROOT release (>v6), it picks the first one in the list return by `spack find` for a given architecture.
2. updates to the retry loop in case of Spack loading issues. A retry is triggered by either the inability to find the correct hash or the failure in loading the package itself.
3. a python3 virtual environement to avoid issues in case setting up Spack brings with it a different python installation. The python environment also helps setting up some required packages once and for all.


