### PR TITLE
Enable number of components in metadata

### DIFF
--- a/Xporter/X_SAM_metadata.py
+++ b/Xporter/X_SAM_metadata.py
@@ -129,12 +129,12 @@ def SAM_metadata(filename):
             raise KeyError(components)
 
 	    # get number of components per subsystem
-        #tpc = SAMUtilities.count_components(components,pattern="icarustpc")
-        #pmt = SAMUtilities.count_components(components,pattern="icaruspmt")
-        #crt = SAMUtilities.count_components(components,pattern="icaruscrt")     
-        #metadata["icarus_components.tpc"] = tpc
-        #metadata["icarus_components.pmt"] = pmt
-        #metadata["icarus_components.crt"] = crt
+        tpc = SAMUtilities.count_components(components,pattern="icarustpc")
+        pmt = SAMUtilities.count_components(components,pattern="icaruspmt")
+        crt = SAMUtilities.count_components(components,pattern="icaruscrt")     
+        metadata["icarus_components.tpc"] = tpc
+        metadata["icarus_components.pmt"] = pmt
+        metadata["icarus_components.crt"] = crt
 
     except KeyError as e:
         logging.error("X_SAM_Metadata.py exception: "+ str(e))
@@ -202,9 +202,9 @@ def SAM_metadata(filename):
     # last check before releasing metadata into the wild
     # make sure all the important fields are there
     try:
-        #metadata["icarus_components.tpc"]
-        #metadata["icarus_components.pmt"]
-        #metadata["icarus_components.crt"]
+        metadata["icarus_components.tpc"]
+        metadata["icarus_components.pmt"]
+        metadata["icarus_components.crt"]
         metadata["icarus_project.version"]
         metadata["icarus_project.name"]
         metadata["icarus_project.stage"]


### PR DESCRIPTION
This PR enables new metadata fields to store the number of components per subsystem that were selected in the run configuration. These are meant to provide an handle to select "good" files that contain all the key components for offline processing.
```
icarus_components.tpc (true_int)
icarus_components.pmt (true_int)
icarus_components.crt (true_int)
```

These fields are added as required values: the Xporter will throw an exception if the component list cannot be found in the run configuration or if these values are empty.

_Currently waiting for final testing...._
