### PR TITLE
update removal policies

### DIFF
--- a/Xporter/removeOldLogFiles.sh
+++ b/Xporter/removeOldLogFiles.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+# remove any logfile older than 90 days
 find /daq/log -type f -mtime +90 -exec rm -f {} \;
+
+# remove broken symlinks
 find /daq/log -type l ! -exec test -e {} \; -exec rm {} \;
-find /daq/log -type d -empty -exec rmdir {} \;
+
+# remove empty directories
+find /daq/log -depth -type d -empty -exec rmdir {} \;
+
+# remove specific logfiles older than 14 days (metrics, triggerdb)
+# fts logs follow same policy, but different script run by root user
 find /daq/log/metrics/* -type f -mtime +14 -exec rm -f {} \;
+find /daq/scratch/log/* -type f -mtime +14 -exec rm -f {} \;
 find /daq/log/triggerdb/* -type f -mtime +14 -exec rm -f {} \;
-rm /daq/log/grafana/graphite/exception.log
-rm /daq/log/grafana/carbon/listener.log


### PR DESCRIPTION
- Added removal of files in `/daq/scratch/log/` that are older than 14 days (similar to what we do for the tpc metrics in `/daq/log/metrics`). 
- Added `-depth` option for the removal of empty directories. This might avoid the race conditions that show up as `No such file or directory` errors in the cronjob emails.
- Added comments