### PR TITLE
updates for token authentication

### DIFF
--- a/FTS_config/crontab_icarusraw_token.ctab
+++ b/FTS_config/crontab_icarusraw_token.ctab
@@ -1,0 +1,3 @@
+MAILTO=mvicenzi@bnl.gov
+# get bearer token for FTS
+1 * * * * /home/nfs/icarusraw/sbndaq-xporter/FTS_config/get_fts_raw_token.sh

--- a/FTS_config/fts.conf
+++ b/FTS_config/fts.conf
@@ -5,18 +5,21 @@ log-file = /opt/fts/fts_logs/fts_${hostname}
 filetypes = data_tape
 samweb-url = https://samicarus.fnal.gov:8483/sam/icarus/api
 sam-web-registry-base-url = https://samicarus.fnal.gov:8483/sam_web_registry
-x509-client-certificate = /opt/fts/fts_proxy/icarusraw.Raw.proxy
-x509-client-key = /opt/fts/fts_proxy/icarusraw.Raw.proxy
+
+## proxy no longer used for authentication
+## token location is passed to FTS via BEARER_TOKEN_FILE env variable
+## x509-client-certificate = /opt/fts/fts_proxy/icarusraw.Raw.proxy
+## x509-client-key = /opt/fts/fts_proxy/icarusraw.Raw.proxy
 
 local-db = /opt/fts/fts_db/${hostname}.db
 
 enable-web-interface = True
 enable-state-graph = True
 web-interface-port = 8787
-#allowed-web-ip = 131.225.*
+## allowed-web-ip = 131.225.*
 
-#transfer-limits = enstore:1
-#max-transfer-limit = 1 
+## transfer-limits = enstore:1
+## max-transfer-limit = 1 
 transfer-retries = 3
 transfer-retry-interval = 300
 

--- a/FTS_config/get_fts_raw_token.sh
+++ b/FTS_config/get_fts_raw_token.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+host=$(hostname | awk -F'.' '{print $1}')
+timestamp=`date +%Y_%m_%d`
+now=`date "+%Y-%m-%d %T"`
+logfile="/daq/log/fts_logs/${host}/icarusraw_token_${host}_${timestamp}.log"
+
+echo "$now : Obtaining icarusraw token on ${host}" >> ${logfile}
+
+htgettoken -i icarus -a htvaultprod.fnal.gov --credkey=icarusraw/managedtokens/fifeutilgpvm01.fnal.gov -r raw --nooidc --nokerberos --nossh --minsecs 5400 >> ${logfile} 2>&1
+
+exit 0

--- a/FTS_config/get_fts_raw_token.sh
+++ b/FTS_config/get_fts_raw_token.sh
@@ -3,10 +3,17 @@
 host=$(hostname | awk -F'.' '{print $1}')
 timestamp=`date +%Y_%m_%d`
 now=`date "+%Y-%m-%d %T"`
-logfile="/daq/log/fts_logs/${host}/icarusraw_token_${host}_${timestamp}.log"
+logfile="/daq/log/fts_logs/${host}/${USER}_token_${host}_${timestamp}.log"
 
-echo "$now : Obtaining icarusraw token on ${host}" >> ${logfile}
+echo "$now : Obtaining ${USER} token on ${host}" >> ${logfile}
 
-htgettoken -i icarus -a htvaultprod.fnal.gov --credkey=icarusraw/managedtokens/fifeutilgpvm01.fnal.gov -r raw --nooidc --nokerberos --nossh --minsecs 5400 >> ${logfile} 2>&1
+# specify token location (default)
+export BEARER_TOKEN_FILE=/run/user/$UID/bt_u$UID
+
+# get token
+htgettoken -v -i icarus -a htvaultprod.fnal.gov --credkey=${USER}/managedtokens/fifeutilgpvm01.fnal.gov -r raw --nooidc --nokerberos --nossh --minsecs 5400 >> ${logfile} 2>&1
+
+# check token is valid
+httokendecode -H >> ${logfile} 2>&1
 
 exit 0

--- a/FTS_config/get_fts_raw_token.sh
+++ b/FTS_config/get_fts_raw_token.sh
@@ -14,6 +14,6 @@ export BEARER_TOKEN_FILE=/run/user/$UID/bt_u$UID
 htgettoken -v -i icarus -a htvaultprod.fnal.gov --credkey=${USER}/managedtokens/fifeutilgpvm01.fnal.gov -r raw --nooidc --nokerberos --nossh --minsecs 5400 >> ${logfile} 2>&1
 
 # check token is valid
-httokendecode -H >> ${logfile} 2>&1
+httokendecode -H -v >> ${logfile} 2>&1
 
 exit 0

--- a/FTS_config/run_fts_container.sh
+++ b/FTS_config/run_fts_container.sh
@@ -18,13 +18,14 @@
 host=$(hostname | awk -F'.' '{print $1}')
 echo "Starting FTS podman container image on ${host}"
 
-# setting the volume paths inside the container to be the same
+# setting the volume paths inside the container
 # matching between actual location and relative paths inside
 # syntax: -v /HOST-DIR:/CONTAINER-DIR
 
 # these are real locations on the current host
 # using the same as the legacy FTS setup
-fts_x509_proxy_dir=/opt/icarusraw
+
+fts_token_dir=/run/user/$UID
 fts_log_dir=/daq/log/fts_logs/$host
 fts_db_dir=/var/tmp
 fts_samcp_log_dir=/var/tmp
@@ -37,11 +38,15 @@ hostport=8787
 mkdir -p $fts_config_dir
 cp $PWD/fts.conf $PWD/sam_cp.cfg $fts_config_dir/
 
-# additional things the run command does:
+# things the run command does:
+# - mount needed directories (matching fts expectations)
+# - pass bearer token location via env variable
 # - set hostname inside the container as ${host}
 # - set $USER inside the container as current user
 # - set container name to fts_${host}
 # - expose hostport for localhost:8787 status page
+# - detach container from current shell
+# - replace container if already running
 
 podman run \
        -v ${fts_log_dir}:/opt/fts/fts_logs \
@@ -49,12 +54,13 @@ podman run \
        -v ${fts_config_dir}:/opt/fts/fts_config \
        -v ${fts_dropbox_dir}:/storage \
        -v ${fts_samcp_log_dir}:/var/tmp \
-       -v ${fts_x509_proxy_dir}:/opt/fts/fts_proxy \
+       -v ${fts_token_dir}:/run/user/$UID \
        -p ${hostport}:8787 \
-       -d \
        --network slirp4netns:port_handler=slirp4netns \
        --hostname ${host} \
        --env USERNAME=${USER} \
+       --env-merge BEARER_TOKEN_FILE=/run/user/$UID/bt_u$UID \
        --name fts_${host} \
+       -d \
        --replace \
        fermifts


### PR DESCRIPTION
This PR updates the FTS configuration to use token authentication:

- added  `get_fts_raw_token.sh` script to `icarusraw` crontab to fetch a new token every hour using `htgettoken`. The output of this command is sent to a logfile for monitoring.
- commented out x509 proxy certificate settings in `fts.conf`.
- updated `run_fts_container.sh` to mount the token location and set the `BEARER_TOKEN_FILE` environment variable.

Closes #18 